### PR TITLE
check added for null undefined values

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -69,7 +69,7 @@ Copyright end */
         let payload = { 'indicator': $scope.indicator, 'fields': $scope.config.resourceField };
         customTagsService.executeAction(_connectorName, _connectorAction, payload).then(function(response){
           $scope.tagsKey = getDisplayKey($scope.config.resourceField);
-          if (response.data[$scope.config.resourceField].length > 0) {
+          if (response.data[$scope.config.resourceField] && response.data[$scope.config.resourceField].length > 0) {
             $scope.noData = false;
             $scope.tooltipErrorMsg = '';
             if ($scope.config.structureSelected !== 'URL') {


### PR DESCRIPTION
On some instance - values are null in CVE and Outbreak tags
Condition check added for null/undefined response

<img width="830" alt="Screenshot 2025-04-04 at 9 19 57 AM" src="https://github.com/user-attachments/assets/5af2743a-26d8-4d22-be29-46e984c02c32" />
<img width="826" alt="Screenshot 2025-04-04 at 9 20 24 AM" src="https://github.com/user-attachments/assets/f6cef79e-b3d5-4094-bc74-d00327bbd99a" />
