### PR TITLE
Release/1.1.0

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -129,7 +129,11 @@ Copyright end */
         return deferred.promise;
       };
 
-  
+      //to keep URL and Tags sorted 
+      $scope.sortTags = function (item) {
+        return item.structureSelected === 'URL' ? Number.MAX_VALUE : item.structureSelected;
+      };
+
       function changeURLTagsSchema(_tagsData, navigationModule) {
         const deferred = $q.defer(); // Create a master deferred
         if (!Array.isArray(_tagsData)) return;

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -129,9 +129,9 @@ Copyright end */
         return deferred.promise;
       };
 
-      //to keep URL and Tags sorted 
+      //to keep URL and Tags sorted  - URL on top and rest sorted in 
       $scope.sortTags = function (item) {
-        return item.structureSelected === 'URL' ? Number.MAX_VALUE : item.structureSelected;
+        return item.structureSelected === 'URL' ? Number.MIN_VALUE : item.tagsKey;
       };
 
       function changeURLTagsSchema(_tagsData, navigationModule) {

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -129,7 +129,7 @@ Copyright end */
         return deferred.promise;
       };
 
-      //to keep URL and Tags sorted  - URL on top and rest sorted in 
+      //to keep URL and Tags sorted  - URL on top and rest sorted in ascending order by tagskey 
       $scope.sortTags = function (item) {
         return item.structureSelected === 'URL' ? Number.MIN_VALUE : item.tagsKey;
       };

--- a/widget/view.html
+++ b/widget/view.html
@@ -16,7 +16,7 @@ Copyright end -->
       <div data-ng-if="processing">
         <cs-spinner></cs-spinner>
       </div>
-      <div data-ng-repeat="item in includedTagsData | orderBy:'tagsKey'">
+      <div data-ng-repeat="item in includedTagsData | orderBy:sortTags">
         <div data-ng-if="item.structureSelected==='URL'" class="padding-top-lg display-inline-flex">
           <div>
             <label class="custom-label-size padding-0 ">{{item.tagsKey}}: </label></div>


### PR DESCRIPTION
Mantis- [1195858]

Issue - As outbreaks are URL type it is better to keep it either initially or later. 
Incase if there are no outbreaks, tags are sorted in ascending order

Fix - URL type kept initial in custom tags and rest of tags sorted in ascending order as per keys

<img width="604" height="351" alt="Screenshot 2025-09-29 at 4 02 23 PM" src="https://github.com/user-attachments/assets/3e2fb152-adb8-464e-be63-8d40a1a091c8" />

<img width="593" height="352" alt="Screenshot 2025-09-29 at 4 02 28 PM" src="https://github.com/user-attachments/assets/adf01c2a-dcd4-45da-a0d2-9293acecfcd4" />




